### PR TITLE
Ensure game initializes and add service worker

### DIFF
--- a/script.js
+++ b/script.js
@@ -588,9 +588,15 @@ class DemonCastleGame {
 // ゲーム初期化
 let game;
 
-document.addEventListener('DOMContentLoaded', () => {
+function initGame() {
     game = new DemonCastleGame();
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initGame);
+} else {
+    initGame();
+}
 
 // サービスワーカー登録（PWA対応の準備）
 if ('serviceWorker' in navigator) {

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', () => {
+  // No-op fetch handler to enable service worker control
+});


### PR DESCRIPTION
## Summary
- Initialize the game immediately if the DOM is already loaded to prevent startup issues
- Add a minimal service worker so registration succeeds

## Testing
- `node --check script.js`
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_688ee1e5e5e883308038374882e36c68