### PR TITLE
Use images for scene backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,8 @@
         <!-- 背景 -->
         <div id="gameBackground" class="game-bg">
             <svg class="scene-bg" viewBox="0 0 800 600" role="img" aria-label="ゲーム背景">
-                <rect width="800" height="600" fill="#2d1b3d"/>
+                <rect id="backgroundColor" width="800" height="600" fill="#2d1b3d"/>
+                <image id="backgroundImage" href="" x="0" y="0" width="800" height="600" preserveAspectRatio="xMidYMid slice" style="display:none;" />
             </svg>
         </div>
         

--- a/script.js
+++ b/script.js
@@ -395,19 +395,32 @@ class DemonCastleGame {
 
     updateBackground(backgroundType) {
         const svg = this.gameBackground.querySelector('.scene-bg');
-        const rect = svg.querySelector('rect');
-        
+        const rect = svg.querySelector('#backgroundColor');
+        const img = svg.querySelector('#backgroundImage');
+
+        // デフォルトでは画像を非表示
+        img.style.display = 'none';
+        img.removeAttribute('href');
+
         switch(backgroundType) {
             case 'cottage':
+                img.setAttribute('href', './images/sick.png');
+                img.style.display = 'block';
                 rect.setAttribute('fill', '#2d1f0f');
                 break;
             case 'forest':
+                img.setAttribute('href', './images/forest.png');
+                img.style.display = 'block';
                 rect.setAttribute('fill', '#0f2d0f');
                 break;
             case 'castle_gate':
+                img.setAttribute('href', './images/maou.png');
+                img.style.display = 'block';
                 rect.setAttribute('fill', '#2d1b3d');
                 break;
             case 'throne_room':
+                img.setAttribute('href', './images/palece.png');
+                img.style.display = 'block';
                 rect.setAttribute('fill', '#1a0033');
                 break;
             case 'altar':


### PR DESCRIPTION
## Summary
- Display PNG images for major scene backgrounds to enhance visuals
- Update background manager to map scene IDs to their corresponding image files

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68901211f0cc83309ddf37dc90901089