### PR TITLE
Replace title SVG with image and adjust start button

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,42 +21,8 @@
     <!-- タイトル画面 -->
     <div id="titleScreen" class="screen active">
         <div class="title-content">
-            <svg class="castle-bg" viewBox="0 0 800 600" role="img" aria-label="魔王城の夜景">
-                <defs>
-                    <linearGradient id="skyGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                        <stop offset="0%" style="stop-color:#1a0033;stop-opacity:1" />
-                        <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
-                    </linearGradient>
-                    <filter id="glow">
-                        <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-                        <feMerge> 
-                            <feMergeNode in="coloredBlur"/>
-                            <feMergeNode in="SourceGraphic"/>
-                        </feMerge>
-                    </filter>
-                </defs>
-                
-                <!-- 夜空 -->
-                <rect width="800" height="600" fill="url(#skyGradient)"/>
-                
-                <!-- 稲妻 -->
-                <path class="lightning" d="M200 50 L220 150 L200 150 L230 250" stroke="#ffffff" stroke-width="3" fill="none" opacity="0"/>
-                <path class="lightning" d="M600 80 L580 180 L600 180 L570 280" stroke="#ffffff" stroke-width="2" fill="none" opacity="0"/>
-                
-                <!-- 魔王城 -->
-                <polygon points="300,500 350,450 450,450 500,500 500,580 300,580" fill="#2d1b3d"/>
-                <polygon points="320,500 330,480 470,480 480,500" fill="#1a0f26"/>
-                <rect x="360" y="460" width="80" height="120" fill="#1a0f26"/>
-                <polygon points="360,460 400,420 440,460" fill="#0d0513"/>
-                
-                <!-- 窓（光る） -->
-                <rect x="380" y="480" width="15" height="20" fill="#ff6b6b" filter="url(#glow)"/>
-                <rect x="405" y="480" width="15" height="20" fill="#ff6b6b" filter="url(#glow)"/>
-                
-                <!-- 霧 -->
-                <ellipse cx="400" cy="570" rx="200" ry="30" fill="#ffffff" opacity="0.1" class="fog"/>
-            </svg>
-            
+            <img class="castle-bg" src="./images/maou.png" alt="魔王城">
+
             <div class="title-text">
                 <h1 class="game-title">伝説の魔王城</h1>
                 <p class="subtitle">Legend of the Demon Castle</p>

--- a/style.css
+++ b/style.css
@@ -116,12 +116,14 @@ body {
     border-radius: 50px;
     transition: all 0.3s ease;
     font-family: inherit;
+    margin: 3rem auto 0;
+    transform: scale(1.2);
 }
 
 .start-button:hover {
     background: rgba(255, 107, 107, 0.4);
     box-shadow: 0 0 30px rgba(255, 107, 107, 0.5);
-    transform: translateY(-2px);
+    transform: scale(1.2) translateY(-2px);
 }
 
 /* ゲーム画面 */


### PR DESCRIPTION
## Summary
- show a static demon castle image instead of complex SVG
- center and enlarge the start button for better placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890a120192c83308c4012dbda5517f6