### PR TITLE
Add images for jail and Mina scenes

### DIFF
--- a/script.js
+++ b/script.js
@@ -223,7 +223,7 @@ const gameScenarios = {
         ]
     },
     12: { // 条件を聞く
-        background: "altar",
+        background: "mina",
         character: "mina",
         speaker: "ミーナ",
         lines: [
@@ -238,7 +238,7 @@ const gameScenarios = {
         ]
     },
     16: { // トゥルーエンド
-        background: "sunrise",
+        background: "mina_spirit",
         character: "sera",
         speaker: "セラ",
         lines: [
@@ -577,6 +577,21 @@ class DemonCastleGame {
                 img.setAttribute('href', './images/maou.png');
                 img.style.display = 'block';
                 rect.setAttribute('fill', '#1a0033');
+                break;
+            case 'dungeon':
+                img.setAttribute('href', './images/rouya.png');
+                img.style.display = 'block';
+                rect.setAttribute('fill', '#0a0a0a');
+                break;
+            case 'mina':
+                img.setAttribute('href', './images/mina.png');
+                img.style.display = 'block';
+                rect.setAttribute('fill', '#330011');
+                break;
+            case 'mina_spirit':
+                img.setAttribute('href', './images/minatenn.png');
+                img.style.display = 'block';
+                rect.setAttribute('fill', '#ff6b4a');
                 break;
             case 'altar':
                 rect.setAttribute('fill', '#330011');


### PR DESCRIPTION
## Summary
- show Mina's portrait and ascension in corresponding scenes
- load jail, Mina, and spirit images in background switcher

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891eb80d1188330b5991106813c426e