### PR TITLE
Restrict Demon King route until story completion

### DIFF
--- a/script.js
+++ b/script.js
@@ -557,6 +557,12 @@ class DemonCastleGame {
     }
 
     startMaouGame() {
+        // 魔王編は本編クリア後に解放
+        if (!localStorage.getItem('maouUnlocked')) {
+            alert('魔王編はストーリーを1回クリアすると解放されます。');
+            return;
+        }
+
         this.hideAllScreens();
         this.gameScreen.classList.add('active');
         this.scenarios = maouScenarios;


### PR DESCRIPTION
## Summary
- prevent Demon King arc from starting unless the main story was cleared once

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea71fcc388330942f7f5fd26ad907